### PR TITLE
Add cross-account migration guide and user vector migration notebook

### DIFF
--- a/CROSS_ACCOUNT_OR_REGION_MIGRATION.md
+++ b/CROSS_ACCOUNT_OR_REGION_MIGRATION.md
@@ -1,0 +1,146 @@
+# Cross-Account / Cross-Region Rekognition Collection Migration
+
+This guide extends the [Amazon Rekognition Face Collection ReIndexing Solution](README.md) to support migrating face collections across AWS accounts or regions.
+
+## Prerequisites
+
+- AWS CLI configured with profiles for both source and destination accounts
+- Python 3.x with boto3 installed
+- Access to the source Rekognition collection and its associated S3 images
+- Permissions to deploy CloudFormation stacks in the destination account
+
+## Migration Workflow
+
+### Step 1: Extract Face Records from Source Collection
+
+Extract face records from the source collection using `ListFaces()` with image S3 mapping and save as a JSON file — the repo includes a helper Jupyter notebook (`helper-modules/0-Data-Preparation.ipynb`) that provides a starting template, though you'll need to implement the `getAdditionalInfo` function to map each FaceId back to its source S3 Bucket and Key.
+
+```bash
+# Example: List faces in the source collection
+aws rekognition list-faces \
+  --collection-id <source-collection-id> \
+  --region <source-region> \
+  --profile <source-profile>
+```
+
+**Output:** A JSON file matching the [expected data format](README.md#expected-data-format).
+
+### Step 2: Make Source Images Accessible from Destination Account
+
+Make source images accessible from the destination account:
+
+- **Option A — Copy images:** Copy/replicate source images to an S3 bucket in the destination account/region using `aws s3 sync`.
+
+  ```bash
+  # Sync from source to destination bucket
+  aws s3 sync s3://<source-bucket>/<prefix> s3://<destination-bucket>/<prefix> \
+    --source-region <source-region> \
+    --region <destination-region>
+  ```
+
+- **Option B — Cross-account access:** Configure a cross-account S3 bucket policy on the source bucket granting `s3:GetObject` to the destination account's Rekognition service role.
+
+  ```json
+  {
+    "Effect": "Allow",
+    "Principal": {
+      "AWS": "arn:aws:iam::<DESTINATION_ACCOUNT_ID>:root"
+    },
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::<SOURCE_BUCKET>/*"
+  }
+  ```
+
+### Step 3: Deploy Reindexing Stack in Destination
+
+Deploy the reindexing CloudFormation stack (`solution-assets/cloudformation_template/template.yaml`) in the destination account/region, specifying your IndexFaces TPS limit, Lambda concurrency quota, and quality filter parameters.
+
+```bash
+aws cloudformation deploy \
+  --template-file solution-assets/cloudformation_template/template.yaml \
+  --stack-name rekognition-reindex \
+  --capabilities CAPABILITY_IAM \
+  --region <destination-region> \
+  --profile <destination-profile>
+```
+
+Alternatively, use the one-click launch links in the [main README](README.md#solution-deployment).
+
+### Step 4: Create Target Collection in Destination
+
+Create the target Rekognition collection in the destination account/region using `aws rekognition create-collection`.
+
+```bash
+aws rekognition create-collection \
+  --collection-id <new-collection-id> \
+  --region <destination-region> \
+  --profile <destination-profile>
+```
+
+### Step 5: Update Records JSON for Destination Environment
+
+Update the records JSON to reflect the destination environment — set `CollectionId` to the new target collection name, and if you copied images (Option A), update `Bucket` to the destination bucket name; if using cross-account access (Option B), keep the original `Bucket`/`Key` values.
+
+```bash
+# Example using jq to update CollectionId and Bucket
+jq '[ .[] | .CollectionId = "<new-collection-id>" | .Bucket = "<destination-bucket>" ]' \
+  source-records.json > destination-records.json
+```
+
+### Step 6: Upload Records to Trigger Reindexing
+
+Upload the records JSON to the `records/` folder inside the S3 bucket created by the CloudFormation stack, which automatically triggers the Step Functions state machine to begin the reindexing process.
+
+```bash
+aws s3 cp destination-records.json \
+  s3://<cfn-created-bucket>/records/destination-records.json \
+  --region <destination-region> \
+  --profile <destination-profile>
+```
+
+### Step 7: Monitor and Validate
+
+Monitor the Step Functions execution in the AWS console and review the DynamoDB results table for old-to-new FaceId mappings, checking the logs table for any records that failed IoU threshold matching or where faces were not detected.
+
+```bash
+# Check Step Functions execution status
+aws stepfunctions list-executions \
+  --state-machine-arn <state-machine-arn> \
+  --region <destination-region> \
+  --profile <destination-profile>
+
+# Scan DynamoDB results table
+aws dynamodb scan \
+  --table-name <results-table-name> \
+  --region <destination-region> \
+  --profile <destination-profile>
+```
+
+## Validation
+
+After migration completes, verify the new collection:
+
+```bash
+# Compare face counts
+aws rekognition describe-collection \
+  --collection-id <new-collection-id> \
+  --region <destination-region> \
+  --profile <destination-profile>
+```
+
+The repo also includes a [validation solution](helper-modules/validation-solution.md) for verifying records.
+
+### Step 8: Migrate User Vectors (Optional)
+
+The reindexing solution migrates face vectors but does not recreate [User Vectors](https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-rekognition-face-search-accuracy-user-vectors/). If your source collection uses `CreateUser` and `AssociateFaces`, use the [User Vector Migration notebook](helper-modules/1-User-Vector-Migration.ipynb) to recreate users and face associations in the target collection using the DynamoDB results table.
+
+## Cleanup
+
+Delete the CloudFormation stack in the destination account when done testing:
+
+```bash
+aws cloudformation delete-stack \
+  --stack-name rekognition-reindex \
+  --region <destination-region> \
+  --profile <destination-profile>
+```

--- a/README.md
+++ b/README.md
@@ -79,9 +79,11 @@ Information regarding each reindex operation will be stored into Amazon DynamoDB
 
 Here is a list of additional sections included in this repository:
 
+* **[Cross-Account or Region Migration](CROSS_ACCOUNT_OR_REGION_MIGRATION.md):** Guide for migrating collections across AWS accounts or regions using this solution.
 * **Helper Modules:**
     - You can find a notebook to help you create the records file.
-    - You can find a solution to help you validate your records file. 
+    - You can find a solution to help you validate your records file.
+    - You can find a notebook to help you migrate user vectors after reindexing.
 * **Documentation:** Details about the reindexing process
 
 ## Security

--- a/helper-modules/1-User-Vector-Migration.ipynb
+++ b/helper-modules/1-User-Vector-Migration.ipynb
@@ -1,0 +1,183 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a1b2c3d4",
+   "metadata": {},
+   "source": [
+    "# 1. Post-Reindexing User Vector Migration\n",
+    "\n",
+    "The ReIndexing Solution migrates face vectors to a new collection using `IndexFaces`, but does not recreate [User Vectors](https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-rekognition-face-search-accuracy-user-vectors/). This notebook reads the DynamoDB results table produced by the reindexing process and recreates users and face-to-user associations in the target collection.\n",
+    "\n",
+    "**Notebook Steps:**\n",
+    "1. Import libraries and define variables\n",
+    "2. Read reindexing results from DynamoDB\n",
+    "3. Create users in the target collection\n",
+    "4. Associate faces to users\n",
+    "5. Verify the target collection\n",
+    "\n",
+    "**Prerequisites:**\n",
+    "- The ReIndexing Solution has completed successfully\n",
+    "- The DynamoDB results table contains the old-to-new FaceId mappings with UserId\n",
+    "\n",
+    "**NOTE: You can run this notebook in SageMaker Studio, JupyterLab, or on your local machine**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1b2c3d4",
+   "metadata": {},
+   "source": [
+    "### 1. Import libraries and define variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "region = 'us-west-2'\n",
+    "session = boto3.Session(region_name=region)\n",
+    "dynamodb_client = session.client('dynamodb')\n",
+    "rek_client = session.client('rekognition')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DynamoDB table created by the ReIndexing Solution CloudFormation stack\n",
+    "results_table_name = \"\"  # e.g. \"RIS-<stack-name>-ReIndexResults\"\n",
+    "\n",
+    "# Target collection where faces were reindexed\n",
+    "target_collection_id = \"\"  # e.g. \"my-new-collection\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1b2c3d4",
+   "metadata": {},
+   "source": [
+    "### 2. Read reindexing results from DynamoDB\n",
+    "\n",
+    "Scan the results table and group the new FaceIds by UserId."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_faces = defaultdict(list)\n",
+    "paginator = dynamodb_client.get_paginator('scan')\n",
+    "\n",
+    "for page in paginator.paginate(TableName=results_table_name):\n",
+    "    for item in page['Items']:\n",
+    "        user_id = item.get('UserID', {}).get('S')\n",
+    "        face_id = item.get('FaceId', {}).get('S')\n",
+    "        if user_id and face_id:\n",
+    "            user_faces[user_id].append(face_id)\n",
+    "\n",
+    "print(f\"Found {len(user_faces)} users:\")\n",
+    "for user_id, faces in user_faces.items():\n",
+    "    print(f\"  {user_id}: {len(faces)} faces - {faces}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "g1b2c3d4",
+   "metadata": {},
+   "source": [
+    "### 3. Create users in the target collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "h1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for user_id in user_faces.keys():\n",
+    "    try:\n",
+    "        rek_client.create_user(CollectionId=target_collection_id, UserId=user_id)\n",
+    "        print(f\"Created user: {user_id}\")\n",
+    "    except rek_client.exceptions.ResourceAlreadyExistsException:\n",
+    "        print(f\"User already exists: {user_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "i1b2c3d4",
+   "metadata": {},
+   "source": [
+    "### 4. Associate faces to users"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "j1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for user_id, face_ids in user_faces.items():\n",
+    "    try:\n",
+    "        response = rek_client.associate_faces(\n",
+    "            CollectionId=target_collection_id,\n",
+    "            UserId=user_id,\n",
+    "            FaceIds=face_ids\n",
+    "        )\n",
+    "        associated = len(response.get('AssociatedFaces', []))\n",
+    "        print(f\"Associated {associated}/{len(face_ids)} faces to user: {user_id}\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"Error associating faces for {user_id}: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "k1b2c3d4",
+   "metadata": {},
+   "source": [
+    "### 5. Verify the target collection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "l1b2c3d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "desc = rek_client.describe_collection(CollectionId=target_collection_id)\n",
+    "print(f\"Collection: {target_collection_id}\")\n",
+    "print(f\"  FaceCount: {desc['FaceCount']}\")\n",
+    "print(f\"  UserCount: {desc['UserCount']}\")\n",
+    "print(f\"  FaceModelVersion: {desc['FaceModelVersion']}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
**Issue #**, if available: [#2](https://github.com/aws-samples/amazon-rekognition-reindexing-solution/issues/2), [#3](https://github.com/aws-samples/amazon-rekognition-reindexing-solution/issues/3)

Description of changes:

Adds support for migrating Rekognition collections across AWS accounts or regions, and a helper notebook for post-reindexing user vector migration.

**Changes**:

1. CROSS_ACCOUNT_OR_REGION_MIGRATION.md — Step-by-step guide for migrating a face collection across AWS accounts or regions using the existing reindexing solution. Covers extracting face records, cross-account S3
access, deploying the stack in the destination, and validation. (Closes [#2](https://github.com/aws-samples/amazon-rekognition-reindexing-solution/issues/2))

2. helper-modules/1-User-Vector-Migration.ipynb — Post-reindexing notebook that reads the DynamoDB results table and recreates user vectors (CreateUser + AssociateFaces) in the target collection. The reindexing
solution only migrates face vectors via IndexFaces and does not handle user vectors. (Closes [#3](https://github.com/aws-samples/amazon-rekognition-reindexing-solution/issues/3))

3. README.md — Updated the "Other sections" list to reference the new migration guide and helper notebook.

**Testing**:

Tested end-to-end migrating a collection (5 faces, 2 users) from one AWS account to another. Verified face counts, user counts, and face-to-user associations match between source and target collections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.